### PR TITLE
fix bug in property signatures for lambdas that always fail

### DIFF
--- a/crossbeam/property_signatures/property_signatures.py
+++ b/crossbeam/property_signatures/property_signatures.py
@@ -347,6 +347,10 @@ def _property_signature_lambda(
     fixed_length: bool = True) -> List[Tuple[float, bool, bool, float]]:
   """Returns a property signature for a lambda value."""
   io_pairs_per_example = _run_lambda(value)
+  if all(not pairs_for_example for pairs_for_example in io_pairs_per_example):
+    # The lambda never ran successfully for any attempted input list for any I/O
+    # example. Let's just return all padding.
+    return [_REDUCED_PADDING] * _SIGNATURE_LENGTH_LAMBDA_VALUE
   signatures_to_reduce = []
   for example_index, pairs in enumerate(io_pairs_per_example):
     for inputs, output in pairs:
@@ -472,3 +476,4 @@ def test():
 
 if __name__ == '__main__':
   test()
+

--- a/crossbeam/property_signatures/property_signatures_test.py
+++ b/crossbeam/property_signatures/property_signatures_test.py
@@ -29,6 +29,7 @@ class CheckerTest(parameterized.TestCase):
   def test_property_signature_value_same_length(self):
     # Construct a variety of Value objects.
     ten = value_module.ConstantValue(10)
+    true = value_module.ConstantValue(True)
     x1 = value_module.InputVariable([1, 2, 3], name='x1')
     v1 = value_module.get_free_variable(0)
     v2 = value_module.get_free_variable(1)
@@ -44,6 +45,9 @@ class CheckerTest(parameterized.TestCase):
     lambda_2 = add_op.apply([v2, v1], free_variables=[v1, v2])
     self.assertEqual(lambda_2.expression(), 'lambda v1, v2: Add(v2, v1)')
 
+    bad_lambda = add_op.apply([v1, true], free_variables=[v1])  # Always fails.
+    self.assertEqual(bad_lambda.expression(), 'lambda v1: Add(v1, True)')
+
     # Try a lot of combinations comparing a Value and OutputValue.
     values = [
         ten,
@@ -51,6 +55,7 @@ class CheckerTest(parameterized.TestCase):
         concrete_1,
         lambda_1,
         lambda_2,
+        bad_lambda,
         value_module.InputVariable([[1], [2], [3]], 'list_input'),
         value_module.ConstantValue(True),
         # Many examples.
@@ -111,3 +116,4 @@ class CheckerTest(parameterized.TestCase):
 
 if __name__ == '__main__':
   absltest.main()
+


### PR DESCRIPTION
If the lambda always fails, we don't find any I/O example pairs for the lambda's behavior, and we have no properties to use. Instead we'll just return a bunch of padding. This does mean all such lambdas will be treated the same, but this is probably ok since we don't want to use those lambdas anyway. The only time this approach could fail is if the solution does use the lambda which does succeed for certain inputs, but somehow our lambda-running procedure doesn't find any argument lists where the lambda runs successfully.