### PR TITLE
More speed

### DIFF
--- a/crossbeam/algorithm/synthesis.py
+++ b/crossbeam/algorithm/synthesis.py
@@ -76,6 +76,9 @@ def copy_operation_value(operation, value, all_values, all_value_dict, trace_val
   assert isinstance(value, value_module.OperationValue)
   arg_values = []
   for v in value.arg_values:
+    # TODO(kshi): line below is only needed because value's repr format changed
+    # between dataset generation and training.
+    v._repr_cache = None
     if v in all_value_dict:
       arg_values.append(all_values[all_value_dict[v]])
     else:

--- a/crossbeam/algorithm/synthesis.py
+++ b/crossbeam/algorithm/synthesis.py
@@ -305,8 +305,6 @@ def synthesize(task, domain, model, device,
         update_stats_value_explored(stats, result_value)
         if result_value is None or result_value.get_weight() > max_weight:
           continue
-        if not property_signatures.is_value_valid(result_value):
-          continue
         if (domain.small_value_filter and
             not all(domain.small_value_filter(v) for v in result_value.values)):
           continue
@@ -314,6 +312,8 @@ def synthesize(task, domain, model, device,
           if not static_weight:
             update_with_better_value(result_value, all_value_dict, all_values,
                                      model, device, output_value, verbose)
+          continue
+        if not property_signatures.is_value_valid(result_value):
           continue
         all_value_dict[result_value] = len(all_values)
         all_values.append(result_value)

--- a/crossbeam/algorithm/synthesis.py
+++ b/crossbeam/algorithm/synthesis.py
@@ -134,11 +134,21 @@ def update_stats_value_kept(stats, value):
 
 def update_stats_with_percents(stats):
   stats.update({
-    'explored_percent_none': stats['num_explored_none'] * 100 / stats['num_values_explored'],
-    'explored_percent_concrete': stats['num_explored_concrete'] * 100 / stats['num_values_explored'],
-    'explored_percent_lambda': stats['num_explored_lambda'] * 100 / stats['num_values_explored'],
-    'kept_percent_concrete': stats['num_kept_concrete'] * 100 / stats['num_values_kept'],
-    'kept_percent_lambda': stats['num_kept_lambda'] * 100 / stats['num_values_kept'],
+      'explored_percent_none':
+          stats['num_explored_none'] * 100 / stats['num_values_explored']
+          if stats['num_values_explored'] else -1,
+      'explored_percent_concrete':
+          stats['num_explored_concrete'] * 100 / stats['num_values_explored']
+          if stats['num_values_explored'] else -1,
+      'explored_percent_lambda':
+          stats['num_explored_lambda'] * 100 / stats['num_values_explored']
+          if stats['num_values_explored'] else -1,
+      'kept_percent_concrete':
+          stats['num_kept_concrete'] * 100 / stats['num_values_kept']
+          if stats['num_values_kept'] else -1,
+      'kept_percent_lambda':
+          stats['num_kept_lambda'] * 100 / stats['num_values_kept']
+          if stats['num_values_kept'] else -1,
   })
 
 

--- a/crossbeam/algorithm/synthesis.py
+++ b/crossbeam/algorithm/synthesis.py
@@ -113,11 +113,48 @@ def decode_args(operation, args, all_values):
   return arg_list, arg_var_list, free_vars
 
 
+def update_stats_value_explored(stats, value):
+  stats['num_values_explored'] += 1
+  if value is None:
+    stats['num_explored_none'] += 1
+  elif value.num_free_variables:
+    stats['num_explored_lambda'] += 1
+  else:
+    stats['num_explored_concrete'] += 1
+
+
+def update_stats_value_kept(stats, value):
+  # Not including trace elements manually added during training.
+  stats['num_values_kept'] += 1
+  if value.num_free_variables:
+    stats['num_kept_lambda'] += 1
+  else:
+    stats['num_kept_concrete'] += 1
+
+
+def update_stats_with_percents(stats):
+  stats.update({
+    'explored_percent_none': stats['num_explored_none'] * 100 / stats['num_values_explored'],
+    'explored_percent_concrete': stats['num_explored_concrete'] * 100 / stats['num_values_explored'],
+    'explored_percent_lambda': stats['num_explored_lambda'] * 100 / stats['num_values_explored'],
+    'kept_percent_concrete': stats['num_kept_concrete'] * 100 / stats['num_values_kept'],
+    'kept_percent_lambda': stats['num_kept_lambda'] * 100 / stats['num_values_kept'],
+  })
+
+
 def synthesize(task, domain, model, device,
                trace=None, max_weight=15, k=2, is_training=False,
                include_as_train=None, timeout=None, max_values_explored=None, is_stochastic=False,
                random_beam=False, use_ur=False, masking=True, static_weight=False):
-  stats = {'num_values_explored': 0}
+  stats = {
+      'num_values_explored': 0,
+      'num_explored_none': 0,
+      'num_explored_concrete': 0,
+      'num_explored_lambda': 0,
+      'num_values_kept': 0,
+      'num_kept_concrete': 0,
+      'num_kept_lambda': 0,
+  }
 
   verbose = False
   end_time = None if timeout is None or timeout < 0 else timeit.default_timer() + timeout
@@ -200,7 +237,8 @@ def synthesize(task, domain, model, device,
           randomizer.mark_sequence_complete()
 
           result_value = operation.apply(arg_list)
-          stats['num_values_explored'] += 1
+          update_stats_value_explored(stats, result_value)
+
           if verbose and result_value is None:
             print('Cannot apply {} to {}'.format(operation, arg_list))
           if result_value is None or result_value.get_weight() > max_weight:
@@ -216,6 +254,7 @@ def synthesize(task, domain, model, device,
           if verbose:
             print('new value: {}, {}'.format(result_value, result_value.expression()))
           new_values.append(result_value)
+          update_stats_value_kept(stats, result_value)
 
         for new_value in new_values:
           all_value_dict[new_value] = len(all_values)
@@ -224,7 +263,7 @@ def synthesize(task, domain, model, device,
             return new_value, (all_values, all_signatures), stats
 
         continue
-      
+
       weight_snapshot = [v.get_weight() for v in all_values]
       if random_beam:
         raise NotImplementedError  #TODO(hadai): enable random beam during training
@@ -253,7 +292,7 @@ def synthesize(task, domain, model, device,
       for beam_pos, args_and_vars in enumerate(args):
         arg_list, arg_vars, free_vars = decode_args(operation, args_and_vars, all_values)
         result_value = operation.apply(arg_list, arg_vars, free_vars)
-        stats['num_values_explored'] += 1
+        update_stats_value_explored(stats, result_value)
         if result_value is None or result_value.get_weight() > max_weight:
           continue
         if not property_signatures.is_value_valid(result_value):
@@ -268,6 +307,7 @@ def synthesize(task, domain, model, device,
           continue
         all_value_dict[result_value] = len(all_values)
         all_values.append(result_value)
+        update_stats_value_kept(stats, result_value)
         if result_value == output_value and not is_training:
           return result_value, (all_values, all_signatures), stats
         # TODO: allow multi-choice when options in trace have the same priority

--- a/crossbeam/algorithm/synthesis.py
+++ b/crossbeam/algorithm/synthesis.py
@@ -157,6 +157,8 @@ def synthesize(task, domain, model, device,
                include_as_train=None, timeout=None, max_values_explored=None, is_stochastic=False,
                random_beam=False, use_ur=False, masking=True, static_weight=False):
   stats = {
+      'num_examples': task.num_examples,
+      'num_inputs': task.num_inputs,
       'num_values_explored': 0,
       'num_explored_none': 0,
       'num_explored_concrete': 0,

--- a/crossbeam/dsl/value.py
+++ b/crossbeam/dsl/value.py
@@ -48,8 +48,12 @@ class Value(abc.ABC):
       if isinstance(self, (FreeVariable, BoundVariable)) or self.free_variables:
         self._repr_cache = self.expression()
       else:
+        values = self.values
+        first_value = values[0]
+        if self.type is int and all(v == first_value for v in values):
+          values = [first_value]
         self._repr_cache = '[' + ', '.join('{}:{!r}'.format(type(v).__name__, v)
-                                           for v in self.values) + ']'
+                                           for v in values) + ']'
     return self._repr_cache
 
   def __hash__(self):

--- a/crossbeam/experiment/deepcoder/deepcoder_main_dist.sh
+++ b/crossbeam/experiment/deepcoder/deepcoder_main_dist.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+date="oct7"
 tout=60
 maxw=14
 maxne=5
@@ -22,7 +22,7 @@ maxni=3
 skip=0.00
 lambdaskip=0.00
 
-data_folder=$HOME/xlambda-data/deepcoder/t-${tout}-maxne-${maxne}-maxni-${maxni}-skip-${skip}-lambdaskip-${lambdaskip}
+data_folder=$HOME/xlambda-data/deepcoder/${date}-t-${tout}-maxne-${maxne}-maxni-${maxni}-skip-${skip}-lambdaskip-${lambdaskip}
 
 beam_size=10
 grad_acc=4
@@ -30,7 +30,7 @@ maxsw=12
 io=lambda_signature
 value=lambda_signature
 
-save_dir=$HOME/results/xlambda/deepcoder/tout-${tout}-io-${io}-value-${value}-b-${beam_size}-g-${grad_acc}
+save_dir=$HOME/xlambda-results/deepcoder/oct20-fast-t-${tout}-io-${io}-value-${value}-b-${beam_size}-g-${grad_acc}
 
 if [ ! -e $save_dir ];
 then
@@ -59,7 +59,8 @@ python3 -m crossbeam.experiment.run_crossbeam \
     --num_proc=8 \
     --gpu_list=0,1,2,3,4,5,6,7 \
     --embed_dim=64 \
-    --eval_every 10000 \
+    --eval_every 5000 \
+    --num_valid 250 \
     --use_ur=False \
     --encode_weight=True \
     --train_steps 1000000 \

--- a/crossbeam/experiment/deepcoder/deepcoder_main_dist.sh
+++ b/crossbeam/experiment/deepcoder/deepcoder_main_dist.sh
@@ -30,7 +30,7 @@ maxsw=12
 io=lambda_signature
 value=lambda_signature
 
-save_dir=$HOME/xlambda-results/deepcoder/oct20-fast-t-${tout}-io-${io}-value-${value}-b-${beam_size}-g-${grad_acc}
+save_dir=$HOME/xlambda-results/deepcoder/oct24-more_speed-t-${tout}-io-${io}-value-${value}-b-${beam_size}-g-${grad_acc}
 
 if [ ! -e $save_dir ];
 then

--- a/crossbeam/experiment/deepcoder/deepcoder_main_single.sh
+++ b/crossbeam/experiment/deepcoder/deepcoder_main_single.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+date="oct7"
 tout=60
 maxw=14
 maxne=5
@@ -22,15 +22,15 @@ maxni=3
 skip=0.00
 lambdaskip=0.00
 
-data_folder=$HOME/xlambda-data/deepcoder/t-${tout}-maxne-${maxne}-maxni-${maxni}-skip-${skip}-lambdaskip-${lambdaskip}
+data_folder=$HOME/xlambda-data/deepcoder/${date}-t-${tout}-maxne-${maxne}-maxni-${maxni}-skip-${skip}-lambdaskip-${lambdaskip}
 
 beam_size=10
-grad_acc=1
+grad_acc=4
 maxsw=12
 io=lambda_signature
 value=lambda_signature
 
-save_dir=$HOME/results/xlambda/deepcoder/tout-${tout}-io-${io}-value-${value}-b-${beam_size}-g-${grad_acc}
+save_dir=$HOME/xlambda-results/deepcoder/oct19-speed-t-${tout}-io-${io}-value-${value}-b-${beam_size}-g-${grad_acc}
 
 if [ ! -e $save_dir ];
 then
@@ -57,8 +57,9 @@ python3 -m crossbeam.experiment.run_crossbeam \
     --grad_accumulate $grad_acc \
     --beam_size $beam_size \
     --num_proc=1 \
-    --embed_dim=64 \
-    --eval_every 10 \
+    --embed_dim=64\
+    --eval_every 1000 \
+    --num_valid 100 \
     --use_ur=False \
     --encode_weight=True \
     --train_steps 1000000 \

--- a/crossbeam/experiment/deepcoder/deepcoder_main_single.sh
+++ b/crossbeam/experiment/deepcoder/deepcoder_main_single.sh
@@ -30,7 +30,7 @@ maxsw=12
 io=lambda_signature
 value=lambda_signature
 
-save_dir=$HOME/xlambda-results/deepcoder/oct19-speed-t-${tout}-io-${io}-value-${value}-b-${beam_size}-g-${grad_acc}
+save_dir=$HOME/xlambda-results/deepcoder/oct24-log-t-${tout}-io-${io}-value-${value}-b-${beam_size}-g-${grad_acc}
 
 if [ ! -e $save_dir ];
 then
@@ -62,8 +62,10 @@ python3 -m crossbeam.experiment.run_crossbeam \
     --num_valid 100 \
     --use_ur=False \
     --encode_weight=True \
-    --train_steps 1000000 \
+    --train_steps 5000 \
     --train_data_glob train-tasks*.pkl \
     --random_beam=False \
     --lr=1e-4 \
     $@
+
+    #--load_model=/home/kshi/xlambda-results/deepcoder/oct24-more_speed-t-60-io-lambda_signature-value-lambda_signature-b-10-g-4/model-best-valid.ckpt \

--- a/crossbeam/experiment/run_crossbeam.py
+++ b/crossbeam/experiment/run_crossbeam.py
@@ -83,6 +83,9 @@ def main(argv):
   for fname in sorted(eval_files):
     with open(os.path.join(FLAGS.data_folder, fname), 'rb') as f:
       eval_tasks += cp.load(f)
+    # Shuffle the evaluation tasks so that when we take the first `num_valid`
+    # tasks, they come from different data-generation searches.
+    random.shuffle(eval_tasks)
 
   proc_args = argparse.Namespace(**FLAGS.flag_values_dict())
   if FLAGS.train_data_glob is not None:

--- a/crossbeam/experiment/train_eval.py
+++ b/crossbeam/experiment/train_eval.py
@@ -246,7 +246,7 @@ def train_eval_loop(args, device, model, train_files, eval_tasks,
 
     # Training
     pbar = tqdm(range(args.eval_every)) if rank == 0 else range(args.eval_every)
-    verbose = True  # TODO(kshi)
+    verbose = False  # TODO(kshi)
     profile = False  # TODO(kshi)
     for _ in pbar:
       grad_step_start_time = timeit.default_timer()

--- a/crossbeam/model/encoder.py
+++ b/crossbeam/model/encoder.py
@@ -158,36 +158,27 @@ class BustlePropSigIOEncoder(nn.Module):
 class LambdaSignature(nn.Module):
   def __init__(self, len_signature):
     super(LambdaSignature, self).__init__()
-    self.frac_applicable_embed = nn.Embedding(12, 2)
-    self.bool_true_embed = nn.Embedding(2, 2)
-    self.bool_false_embed = nn.Embedding(2, 2)
-    self.frac_tf_embed = nn.Embedding(12, 2)
+    self.tuple_length = deepcoder_propsig.SIGNATURE_TUPLE_LENGTH
+    self.embed_length = 2
+    self.frac_applicable_embed = nn.Embedding(12, self.embed_length)
+    self.frac_tf_embed = nn.Embedding(12, self.embed_length)
     self.len_signature = len_signature
 
   def quantize(self, sig):
-    if sig == 0:
-      return 0
-    return int(sig * 10) + 1
+    return torch.where(sig == 0, 0, (sig * 10).floor() + 1)
 
   def forward(self, list_signatures, device):
-    list_frac_app = []
-    list_all_true = []
-    list_all_false = []
-    list_frac_tf = []
-    for signature in list_signatures:
-      frac_app, all_true, all_false, frac_tf = zip(*signature)
-      list_frac_app.append([self.quantize(sig) for sig in frac_app])
-      list_all_true.append([int(sig) for sig in all_true])
-      list_all_false.append([int(sig) for sig in all_false])
-      list_frac_tf.append([self.quantize(sig) for sig in frac_tf])
-    list_embed = []
-    for raw_feat, mod in zip([list_frac_app, list_all_true, list_all_false, list_frac_tf],
-                             [self.frac_applicable_embed, self.bool_true_embed, self.bool_false_embed, self.frac_tf_embed]):
-      feat_mat = torch.LongTensor(raw_feat).to(device)
-      embed = mod(feat_mat).view(-1, self.len_signature * 2)
-      list_embed.append(embed)
-    feat_embed = torch.cat(list_embed, dim=-1)
-    return feat_embed
+    # shape: [num signatures, self.len_signature, self.tuple_length]
+    signatures = torch.FloatTensor(list_signatures).to(device)
+    signatures = self.quantize(signatures).long()
+    # shape: [num signatures, self.len_signature, self.tuple_length, self.embed_length]
+    embed = torch.cat([
+        self.frac_applicable_embed(signatures[:, :, 0:1]),
+        self.frac_tf_embed(signatures[:, :, 1:2])
+    ], dim=2)
+    # shape: [num signatures, self.len_signature * self.tuple_length * self.embed_length]
+    flat_embed = embed.view(embed.shape[0], -1)
+    return flat_embed
 
 
 class LambdaSigIOEncoder(LambdaSignature):
@@ -195,7 +186,7 @@ class LambdaSigIOEncoder(LambdaSignature):
     super(LambdaSigIOEncoder, self).__init__(deepcoder_propsig.IO_EXAMPLES_SIGNATURE_LENGTH)
     self.max_num_inputs = max_num_inputs
     self.mlp = nn.Sequential(
-      nn.Linear(self.len_signature * 4 * 2, hidden_size * 2),
+      nn.Linear(self.len_signature * self.tuple_length * self.embed_length, hidden_size * 2),
       nn.ReLU(),
       nn.Linear(hidden_size * 2, hidden_size * 2)
     )
@@ -383,7 +374,7 @@ class LambdaSigValueEncoder(LambdaSignature):
     self.freevar_embed = nn.Parameter(torch.zeros(MAX_NUM_FREE_VARS, hidden_size))
     nn.init.xavier_uniform_(self.freevar_embed)
     self.mlp = nn.Sequential(
-      nn.Linear(self.len_signature * 4 * 2, hidden_size * 2),
+      nn.Linear(self.len_signature * self.tuple_length * self.embed_length, hidden_size * 2),
       nn.ReLU(),
       nn.Linear(hidden_size * 2, hidden_size)
     )

--- a/crossbeam/property_signatures/eval_property_signatures.py
+++ b/crossbeam/property_signatures/eval_property_signatures.py
@@ -16,11 +16,6 @@ import numpy as np
 VERBOSITY = 2
 
 
-def sig_to_np(sig):
-  return np.array([[frac_applicable, frac_true]
-                   for frac_applicable, _, _, frac_true in sig])
-
-
 def sig_distance(x, y):
   return np.linalg.norm(x - y)
 
@@ -125,12 +120,12 @@ def evaluate_property_signatures(value_set, output_value):
         f'values with unique functionality.')
   print()
 
-  concrete_sigs_np = [sig_to_np(sig) for sig in concrete_sigs]
-  lambda_sigs_np = [sig_to_np(sig) for sig in lambda_sigs]
+  concrete_sigs_np = [np.array(sig) for sig in concrete_sigs]
+  lambda_sigs_np = [np.array(sig) for sig in lambda_sigs]
 
-  print('For concrete signatures:')
-  analyze_distances(concrete_values, concrete_sigs_np)
-  print()
+  #print('For concrete signatures:')
+  #analyze_distances(concrete_values, concrete_sigs_np)
+  #print()
 
   print('For lambda signatures:')
   analyze_distances(lambda_values, lambda_sigs_np)
@@ -146,15 +141,18 @@ def main(argv):
       'lst': [[1, 2, 3], [4, 5, 6]],
   }
   outputs = [
-      [4, 5, 6],
-      [9, 10, 11],
+      [4, 5],
+      [9, 10],
+      #[4, 5, 6],
+      #[9, 10, 11],
   ]
   task = task_module.Task(inputs_dict, outputs, solution='')
   domain = domains.get_domain('deepcoder')
   result, value_set, _, _ = baseline_enumeration.synthesize_baseline(
-      task, domain, timeout=5)
+      task, domain, timeout=60)
+  print(f'Found solution: {result.expression()}')
   assert (result.expression() ==
-          'Map(lambda u1: (lambda v1: Add(delta, v1))(u1), lst)')
+          'Take(-1, Map(lambda u1: (lambda v1: Add(delta, v1))(u1), lst))')
 
   value_set = sorted(list(value_set), key=str)
 

--- a/crossbeam/property_signatures/eval_property_signatures.py
+++ b/crossbeam/property_signatures/eval_property_signatures.py
@@ -70,10 +70,12 @@ def evaluate_property_signatures(value_set, output_value, profile=False):
 
   start_time = timeit.default_timer()
   if profile:
-    with cProfile.Profile() as pr:
-      lambda_sigs = [
-          property_signatures.property_signature_value(v, output_value)
-          for v in lambda_values]
+    pr = cProfile.Profile()
+    pr.enable()
+    lambda_sigs = [
+        property_signatures.property_signature_value(v, output_value)
+        for v in lambda_values]
+    pr.disable()
     pr.print_stats(sort='cumtime')
   else:
     lambda_sigs = [

--- a/crossbeam/property_signatures/property_signatures.py
+++ b/crossbeam/property_signatures/property_signatures.py
@@ -128,15 +128,15 @@ def _basic_properties(x) -> List[bool]:
         x % 2 == 0,
         abs_x < 5,
         abs_x < 10,
-        abs_x < 15,
+        # abs_x < 15,
         abs_x < 20,
-        abs_x < 30,
-        abs_x < 40,
+        # abs_x < 30,
+        # abs_x < 40,
         abs_x < 50,
-        abs_x < 75,
+        # abs_x < 75,
         abs_x < 100,
-        abs_x < 150,
-        abs_x < 200,
+        # abs_x < 150,
+        # abs_x < 200,
     ]
   elif type_x is list:
     sorted_x = list(sorted(x))
@@ -145,8 +145,8 @@ def _basic_properties(x) -> List[bool]:
     return [
         x == sorted_x,
         x == reverse_sorted_x,
-        num_unique == 1,
-        num_unique <= len(x) // 2,
+        # num_unique == 1,
+        # num_unique <= len(x) // 2,
         num_unique == len(x),
     ]
   else:
@@ -212,16 +212,16 @@ def _compare_same_type(x, y) -> List[bool]:
         x == y,
         x < y,
         x > y,
-        x != 0 and y % x == 0,
-        y != 0 and x % y == 0,
+        # x != 0 and y % x == 0,
+        # y != 0 and x % y == 0,
         abs_diff < 2,
-        abs_diff < 5,
+        # abs_diff < 5,
         abs_diff < 10,
-        abs_diff < 20,
-        abs_diff < 50,
-        abs_diff < 100,
-        abs_diff < 200,
-        (x >= 0) == (y >= 0),  # Signs are the same.
+        # abs_diff < 20,
+        # abs_diff < 50,
+        # abs_diff < 100,
+        # abs_diff < 200,
+        # (x >= 0) == (y >= 0),  # Signs are the same.
     ]
   elif type_x is list:
     unique_x = set(x)
@@ -239,6 +239,7 @@ def _compare_same_type(x, y) -> List[bool]:
         all(xi > yi for xi, yi in zip(x, y)),
         all(xi >= yi for xi, yi in zip(x, y)),
         all(xi == yi for xi, yi in zip(x, y)),  # One is prefix of the other.
+        all(xi != yi for xi, yi in zip(x, y)),
         unique_x == unique_y,
         unique_x.issubset(unique_y),
         unique_y.issubset(unique_x),

--- a/crossbeam/property_signatures/property_signatures.py
+++ b/crossbeam/property_signatures/property_signatures.py
@@ -131,8 +131,7 @@ def _basic_properties(x) -> List[bool]:
         abs_x < 5,
         abs_x < 10,
         abs_x < 20,
-        abs_x < 30,
-        abs_x < 40,
+        abs_x < 35,
         abs_x < 50,
         abs_x < 75,
         abs_x < 100,
@@ -202,7 +201,7 @@ def _compare_same_type(x, y) -> List[bool]:
   if x is None:
     return []
   elif type_x is bool:
-    return [x == y, x and y, x or y]
+    return [x == y]
   elif type_x is int:
     abs_diff = abs(x - y)
     return [

--- a/crossbeam/property_signatures/property_signatures.py
+++ b/crossbeam/property_signatures/property_signatures.py
@@ -53,7 +53,6 @@ length signatures).
 # pylint: disable=unidiomatic-typecheck
 
 import itertools
-import random
 from typing import Any, List, Optional, Tuple, Type
 
 from crossbeam.dsl import deepcoder_operations
@@ -64,16 +63,30 @@ DEFAULT_VALUES = {
     bool: False,
     int: 0,
     list: [0],
+    type(None): None,
 }
 
 # DeepCoder only uses lambdas that take int(s) as input.
 VALUES_TO_TRY = {
-    int: [-176, -67, -31, -7, -3, -2, -1, 0, 1, 2, 3, 5, 16, 25, 83, 130],
-    #int: (
-    #    [-176, -97, -55, -28, -13] +
-    #    list(range(-10, 11)) +
-    #    [16, 35, 66, 85, 143, 239]
-    #),
+    int: {
+        1: [-177, -84, -17, -3, -2, -1, 0, 1, 2, 3, 4, 5, 12, 47, 110, 213],
+        2: [[0, 0],
+            [0, -13],
+            [1, 5],
+            [2, 3],
+            [3, -1],
+            [4, 1],
+            [6, 0],
+            [12, 12],
+            [41, 4],
+            [104, -177],
+            [-1, 2],
+            [-2, -3],
+            [-4, 8],
+            [-17, -16],
+            [-76, 173],
+            [-200, -26]],
+    },
 }
 
 # The maximum number of inputs for a lambda Value or an I/O example, if
@@ -82,18 +95,26 @@ VALUES_TO_TRY = {
 FIXED_NUM_IO_INPUTS = 3
 FIXED_NUM_LAMBDA_INPUTS = 2
 
+SignatureTupleType = Tuple[float, float]
+_REDUCED_PADDING = (0.0, 0.5)
+SIGNATURE_TUPLE_LENGTH = len(_REDUCED_PADDING)
+
+SinglePropertyType = Union[bool, int]
+
 
 def _type_property(x) -> List[bool]:
   """Returns a one-hot List[bool] representation of type(x)."""
   type_x = type(x)
   is_lambda = getattr(x, 'num_free_variables', 0) > 0
-  return [is_lambda, type_x is bool, type_x is int, type_x is list]
+  return [is_lambda, type_x is bool, type_x is int, type_x is list, x is None]
 
 
 def _basic_properties(x) -> List[bool]:
   """Returns a list of basic properties for an object."""
   type_x = type(x)
-  if type_x is bool:
+  if x is None:
+    return []
+  elif type_x is bool:
     return [x]
   elif type_x is int:
     abs_x = abs(x)
@@ -135,7 +156,9 @@ def _basic_properties(x) -> List[bool]:
 def _relevant(x) -> List[Any]:
   """Gets related objects relevant to understanding x."""
   type_x = type(x)
-  if type_x is bool:
+  if x is None:
+    return []
+  elif type_x is bool:
     return [x]
   elif type_x is int:
     return [x]
@@ -152,32 +175,36 @@ def _relevant(x) -> List[Any]:
     raise NotImplementedError(f'x has unhandled type {type(x)}')
 
 
-def _basic_signature(x, fixed_length) -> List[Optional[bool]]:
-  """Returns a signature representing a single concrete object."""
-  if not fixed_length:
-    return _type_property(x) + sum((_basic_properties(r) for r in _relevant(x)),
-                                   [])
-  else:
-    type_x = type(x)
-    basic_signature = _basic_signature(x, fixed_length=False)
-    result = []
-    for t in DEFAULT_VALUES:
-      result.extend(basic_signature if type_x is t
-                    else [None] * _BASIC_SIGNATURE_LENGTH_BY_TYPE[t])
-    return result
+def _basic_properties_of_relevant(x) -> List[Any]:
+  return sum((_basic_properties(r) for r in _relevant(x)), [])
 
-
-_BASIC_SIGNATURE_LENGTH_BY_TYPE = {
-    t: len(_basic_signature(DEFAULT_VALUES[t], fixed_length=False))
+_BASIC_PROPERTIES_OF_RELEVANT_LENGTH_BY_TYPE = {
+    t: len(_basic_properties_of_relevant(DEFAULT_VALUES[t]))
     for t in DEFAULT_VALUES
 }
+
+
+def _basic_signature(x, fixed_length) -> List[SinglePropertyType]:
+  """Returns a signature representing a single concrete object."""
+  if not fixed_length:
+    return _type_property(x) + _basic_properties_of_relevant(x)
+  else:
+    result = list(_type_property(x))
+    type_x = type(x)
+    for t in DEFAULT_VALUES:
+      result.extend(
+          _basic_properties_of_relevant(x) if type_x is t
+          else [-1] * _BASIC_PROPERTIES_OF_RELEVANT_LENGTH_BY_TYPE[t])
+    return result
 
 
 def _compare_same_type(x, y) -> List[bool]:
   """Returns a List[bool] comparing two objects of the same type."""
   type_x = type(x)
   assert type_x == type(y)
-  if type_x is bool:
+  if x is None:
+    return []
+  elif type_x is bool:
     return [x == y, x and y, x or y]
   elif type_x is int:
     abs_diff = abs(x - y)
@@ -220,7 +247,7 @@ def _compare_same_type(x, y) -> List[bool]:
     raise NotImplementedError(f'x has unhandled type {type(x)}')
 
 
-def _compare(x, y, fixed_length, x_types=None) -> List[Optional[bool]]:
+def _compare(x, y, fixed_length, x_types=None) -> List[SinglePropertyType]:
   """Compares two concrete (non-lambda) objects of any type."""
   type_x = type(x)
   type_y = type(y)
@@ -242,7 +269,7 @@ def _compare(x, y, fixed_length, x_types=None) -> List[Optional[bool]]:
     for (type_1, type_2) in type_pairs:
       result.extend(_compare(x, y, fixed_length=False)
                     if (type_x, type_y) == (type_1, type_2)
-                    else [None] * _COMPARE_LENGTH_BY_TYPES[(type_1, type_2)])
+                    else [-1] * _COMPARE_LENGTH_BY_TYPES[(type_1, type_2)])
     return result
 
 
@@ -258,7 +285,8 @@ def _property_signature_single_example(
     output: Any,
     fixed_length: bool = True,
     fixed_num_inputs: int = FIXED_NUM_IO_INPUTS,
-    input_types: Optional[List[Type[Any]]] = None) -> List[Optional[bool]]:
+    input_types: Optional[List[Type[Any]]] = None,
+    include_input_basic_signatures: bool = True) -> List[SinglePropertyType]:
   """Returns a property signature for a single I/O example."""
   if not fixed_length:
     return _basic_signature(output, fixed_length) + sum(
@@ -268,15 +296,15 @@ def _property_signature_single_example(
   else:
     if len(inputs) > fixed_num_inputs:
       inputs = inputs[:fixed_num_inputs]
-    result = _basic_signature(output, fixed_length)
+    result = list(_basic_signature(output, fixed_length))
     basic_sig_length = len(result)
-    result.extend(sum(
-        (_basic_signature(i, fixed_length) + _compare(i, output, fixed_length,
-                                                      x_types=input_types)
-         for i in inputs), []))
+    for i in inputs:
+      if include_input_basic_signatures:
+        result.extend(_basic_signature(i, fixed_length))
+      result.extend(_compare(i, output, fixed_length, x_types=input_types))
     if len(inputs) < fixed_num_inputs:
       assert (len(result) - basic_sig_length) % len(inputs) == 0
-      result.extend([None] * (
+      result.extend([-1] * (
           (len(result) - basic_sig_length) // len(inputs) *  # Length per input
           (fixed_num_inputs - len(inputs))))  # Number of inputs to pad
     return  result
@@ -285,15 +313,15 @@ def _property_signature_single_example(
 def _property_signature_single_object(
     x: Any,
     output: Any,
-    fixed_length: bool = True) -> List[Optional[bool]]:
+    fixed_length: bool = True) -> List[SinglePropertyType]:
   """Returns a property signature for an object in context of an I/O example."""
   return _basic_signature(x, fixed_length) + _compare(x, output, fixed_length)
 
 
 def _reduce_across_examples(
-    signatures: List[List[Optional[bool]]]
-) -> List[Tuple[float, bool, bool, float]]:
-  """Reduce across examples (frac applicable, all True?, all False?, frac True)."""
+    signatures: List[List[SinglePropertyType]]
+) -> List[SignatureTupleType]:
+  """Reduce across examples (frac applicable, frac True)."""
   # All signatures should have the same length across examples.
   num_examples = len(signatures)
   assert num_examples
@@ -302,17 +330,29 @@ def _reduce_across_examples(
 
   result = []
   for bools in zip(*signatures):
-    bools_not_none = [x for x in bools if x is not None]
-    num_not_none = len(bools_not_none)
-    frac_true = sum(bools_not_none) / num_not_none if num_not_none else 0.5
-    result.append((len(bools_not_none) / num_examples, frac_true))
+    num_true = bools.count(True)
+    num_not_none = num_true + bools.count(False)
+    frac_applicable = num_not_none / num_examples
+    frac_true = num_true / num_not_none if num_not_none else 0.5
+    result.append((frac_applicable, frac_true))
   return result
+
+  # Alternative numpy implementation, but it's slightly slower because
+  # np.array() is slow.
+
+  # num_examples = len(signatures)
+  # array = np.array(signatures, dtype=np.int8)
+  # num_true = np.sum(array == 1, axis=0)
+  # num_not_none = np.sum(array != -1, axis=0)
+  # frac_applicable = num_not_none / num_examples
+  # frac_true = np.where(num_not_none, num_true / num_not_none, 0.5)
+  # return list(zip(frac_applicable, frac_true))
 
 
 def property_signature_io_examples(
     input_values: List[value_module.Value],
     output_value: value_module.Value,
-    fixed_length: bool = True) -> List[Tuple[float, bool, bool, float]]:
+    fixed_length: bool = True) -> List[SignatureTupleType]:
   """Returns a property signature for a set of I/O examples."""
   num_examples = output_value.num_examples
   assert all(i_value.num_examples == num_examples for i_value in input_values)
@@ -333,7 +373,7 @@ IO_EXAMPLES_SIGNATURE_LENGTH = len(property_signature_io_examples(
 def _property_signature_concrete_value(
     value: value_module.Value,
     output_value: value_module.Value,
-    fixed_length: bool = True) -> List[Tuple[float, bool, bool, float]]:
+    fixed_length: bool = True) -> List[SignatureTupleType]:
   """Returns a property signature for a value w.r.t. a set of I/O examples."""
   assert value.num_free_variables == 0
   return _reduce_across_examples(
@@ -344,30 +384,29 @@ def _property_signature_concrete_value(
 
 def run_lambda(
     value: value_module.Value,
-) -> Optional[List[List[Tuple[List[Any], Any]]]]:
+) -> Optional[List[Tuple[List[Any], Any, int]]]:
   """Runs a lambda on canonical values."""
   arity = value.num_free_variables
   assert arity > 0
-  num_examples = value.num_examples
-  io_pairs_per_example = [[] for _ in range(num_examples)]
-  inputs_to_try = sum(VALUES_TO_TRY.values(), [])
-  for i, (lambda_fn, io_pairs) in enumerate(zip(value.values, io_pairs_per_example)):
-    shuffled_product = list(itertools.product(inputs_to_try, repeat=arity))
-    random.Random(i).shuffle(shuffled_product)
-    for inputs_list in shuffled_product:
-      try:
-        result = lambda_fn(*inputs_list)
-        if domains.deepcoder_small_value_filter(result):
-          io_pairs.append((inputs_list, result))
-          if len(io_pairs) >= 10:
-            break
-      except:  # pylint: disable=bare-except
-        pass
-  if all(not pairs_for_example for pairs_for_example in io_pairs_per_example):
+  io_with_example_index_list = []
+  to_try = VALUES_TO_TRY[int][arity]
+  if arity == 1:
+    to_try = [[i] for i in to_try]
+  for try_index, inputs_list in enumerate(to_try):
+    example_index = try_index % value.num_examples
+    lambda_fn = value[example_index]
+    try:
+      result = lambda_fn(*inputs_list)
+      if not domains.deepcoder_small_value_filter(result):
+        result = None
+      io_with_example_index_list.append((inputs_list, result, example_index))
+    except:  # pylint: disable=bare-except
+      pass
+  if all(result is None for _, result, _ in io_with_example_index_list):
     # The lambda never ran successfully for any attempted input list for any I/O
     # example. Return None to signal this.
     return None
-  return io_pairs_per_example
+  return io_with_example_index_list
 
 
 def is_value_valid(value: value_module.Value) -> bool:
@@ -377,38 +416,38 @@ def is_value_valid(value: value_module.Value) -> bool:
     return True
   if not hasattr(value, 'lambda_exec_results'):
     value.lambda_exec_results = run_lambda(value)
-  return value.lambda_exec_results != None
+  return value.lambda_exec_results is not None
 
 
 def _property_signature_lambda(
     value: value_module.Value,
     output_value: value_module.Value,
-    fixed_length: bool = True) -> List[Tuple[float, bool, bool, float]]:
+    fixed_length: bool = True) -> List[SignatureTupleType]:
   """Returns a property signature for a lambda value."""
   if not hasattr(value, 'lambda_exec_results'):
     value.lambda_exec_results = run_lambda(value)
-  io_pairs_per_example = value.lambda_exec_results
-  if not io_pairs_per_example:
+  io_with_example_index_list = value.lambda_exec_results
+  if not io_with_example_index_list:
     # The lambda never ran successfully. We return all padding here, but such a
     # value shouldn't be kept in search.
     return [_REDUCED_PADDING] * _SIGNATURE_LENGTH_LAMBDA_VALUE
   signatures_to_reduce = []
-  for example_index, pairs in enumerate(io_pairs_per_example):
-    for inputs, output in pairs:
-      signatures_to_reduce.append(
-          _type_property(value) +
-          _compare(output, output_value[example_index], fixed_length) +
-          _property_signature_single_example(
+  for inputs, output, example_index in io_with_example_index_list:
+    signatures_to_reduce.append(
+        _type_property(value) +
+        _compare(output, output_value[example_index], fixed_length) +
+        _property_signature_single_example(
             inputs, output, fixed_length,
             fixed_num_inputs=FIXED_NUM_LAMBDA_INPUTS,
-            input_types=list(VALUES_TO_TRY)))
+            input_types=list(VALUES_TO_TRY),
+            include_input_basic_signatures=False))
   return _reduce_across_examples(signatures_to_reduce)
 
 
 def property_signature_value(
     value: value_module.Value,
     output_value: value_module.Value,
-    fixed_length: bool = True) -> List[Tuple[float, bool, bool, float]]:
+    fixed_length: bool = True) -> List[SignatureTupleType]:
   """Returns a property signature for a Value w.r.t. to the output Value."""
   if not fixed_length:
     if value.num_free_variables:
@@ -425,8 +464,6 @@ def property_signature_value(
                                                  fixed_length) +
               [_REDUCED_PADDING] * _SIGNATURE_LENGTH_LAMBDA_VALUE)
 
-_REDUCED_PADDING = (0.0, 0.5)
-SIGNATURE_TUPLE_LENGTH = len(_REDUCED_PADDING)
 _SIGNATURE_LENGTH_CONCRETE_VALUE = len(_property_signature_concrete_value(
     value_module.ConstantValue(0), value_module.OutputValue([1]),
     fixed_length=True))
@@ -447,7 +484,8 @@ def test():
   """Run some functions and print results to stdout."""
   import timeit  # pylint: disable=g-import-not-at-top
   fixed_length = True
-  print(f'_BASIC_SIGNATURE_LENGTH_BY_TYPE: {_BASIC_SIGNATURE_LENGTH_BY_TYPE}')
+  print(f'_BASIC_PROPERTIES_OF_RELEVANT_LENGTH_BY_TYPE: '
+        f'{_BASIC_PROPERTIES_OF_RELEVANT_LENGTH_BY_TYPE}')
   print(f'_COMPARE_LENGTH_BY_TYPES: {_COMPARE_LENGTH_BY_TYPES}')
   print(f'_SIGNATURE_LENGTH_CONCRETE_VALUE: {_SIGNATURE_LENGTH_CONCRETE_VALUE}')
   print(f'_SIGNATURE_LENGTH_LAMBDA_VALUE: {_SIGNATURE_LENGTH_LAMBDA_VALUE}')
@@ -486,10 +524,10 @@ def test():
 
   lambda_value = Mock()
   lambda_value.values = [
-      lambda x, y: ([e + 3*y for e in x]  # pylint: disable=g-long-lambda
-                    if type(x) == list and type(y) == int else None),
-      lambda x, y: ([e + -1*y for e in x]  # pylint: disable=g-long-lambda
-                    if type(x) == list and type(y) == int else None),
+      lambda x, y: (x + 3*y  # pylint: disable=g-long-lambda
+                    if type(x) == int and type(y) == int else None),
+      lambda x, y: (x + -1*y  # pylint: disable=g-long-lambda
+                    if type(x) == int and type(y) == int else None),
   ]
   lambda_value.num_examples = 2
   lambda_value.num_free_variables = 2

--- a/crossbeam/property_signatures/property_signatures.py
+++ b/crossbeam/property_signatures/property_signatures.py
@@ -126,17 +126,16 @@ def _basic_properties(x) -> List[bool]:
         x > 0,
         x < 0,
         x % 2 == 0,
+        x % 3 == 0,
+        x % 3 == 1,
         abs_x < 5,
         abs_x < 10,
-        # abs_x < 15,
         abs_x < 20,
-        # abs_x < 30,
-        # abs_x < 40,
+        abs_x < 30,
+        abs_x < 40,
         abs_x < 50,
-        # abs_x < 75,
+        abs_x < 75,
         abs_x < 100,
-        # abs_x < 150,
-        # abs_x < 200,
     ]
   elif type_x is list:
     sorted_x = list(sorted(x))
@@ -145,8 +144,6 @@ def _basic_properties(x) -> List[bool]:
     return [
         x == sorted_x,
         x == reverse_sorted_x,
-        # num_unique == 1,
-        # num_unique <= len(x) // 2,
         num_unique == len(x),
     ]
   else:
@@ -212,16 +209,12 @@ def _compare_same_type(x, y) -> List[bool]:
         x == y,
         x < y,
         x > y,
-        # x != 0 and y % x == 0,
-        # y != 0 and x % y == 0,
+        x != 0 and y % x == 0,
+        y != 0 and x % y == 0,
         abs_diff < 2,
-        # abs_diff < 5,
+        abs_diff < 5,
         abs_diff < 10,
-        # abs_diff < 20,
-        # abs_diff < 50,
-        # abs_diff < 100,
-        # abs_diff < 200,
-        # (x >= 0) == (y >= 0),  # Signs are the same.
+        abs_diff < 20,
     ]
   elif type_x is list:
     unique_x = set(x)

--- a/crossbeam/property_signatures/property_signatures.py
+++ b/crossbeam/property_signatures/property_signatures.py
@@ -53,7 +53,7 @@ length signatures).
 # pylint: disable=unidiomatic-typecheck
 
 import itertools
-from typing import Any, List, Optional, Tuple, Type
+from typing import Any, List, Optional, Tuple, Type, Union
 
 from crossbeam.dsl import deepcoder_operations
 from crossbeam.dsl import domains

--- a/crossbeam/property_signatures/property_signatures_test.py
+++ b/crossbeam/property_signatures/property_signatures_test.py
@@ -79,7 +79,7 @@ class CheckerTest(parameterized.TestCase):
         signature = property_signatures.property_signature_value(
             value, output, fixed_length=True)
         lengths.append(len(signature))
-        self.assertTrue(all(len(element) == 4 for element in signature))
+        self.assertTrue(all(len(element) == 2 for element in signature))
 
     self.assertLen(set(lengths), 1)  # All lengths should be the same.
 
@@ -110,7 +110,7 @@ class CheckerTest(parameterized.TestCase):
         signature = property_signatures.property_signature_io_examples(
             inputs, output, fixed_length=True)
         lengths.append(len(signature))
-        self.assertTrue(all(len(element) == 4 for element in signature))
+        self.assertTrue(all(len(element) == 2 for element in signature))
 
     self.assertLen(set(lengths), 1)  # All lengths should be the same.
 


### PR DESCRIPTION
From `eval_property_signatures.py`, we get the following improvements:
* Concrete value signature time: 0.62 -> 0.34 ms per value (1.8x speedup)
* Lambda signature time: 18.29 -> 1.21 ms per value (15x speedup)
* Signature length: 2167 -> 917 (2.36x reduction)
* Concrete signature collisions: 68 -> 44
* “Avoidable” concrete signature collisions: 27 -> 3

I can now train with approximately 1.6 sec / it, on 8 GPU with grad_acc=4 (so 4 synthesis searches per "iteration").

Summary of changes

We run lambdas fewer times:
* Instead of having 32 canonical ints and 32^2=1024 canonical pairs of ints, I've handwritten 16 canonical ints and 16 canonical pairs of ints.
* Instead of running a lambda on all canonical input lists of the appropriate arity for all examples, we only use each input list once and do a round-robin through examples.

Signatures are shorter:
* Because lambdas are run on all canonical input lists (of the appropriate arity), not ignoring any inputs anymore (elaborated below), it is unnecessary to spend signature space describing the inputs themselves (they are constant given the arity).
* I/O examples may have 3 inputs but lambdas have at most 2 inputs. We used to pad all input lists to 3 inputs, but now we pad to 2 for lambdas.
* I removed some properties, targeting those that contributed a lot to the overall signature length but were the least useful in distinguishing different values. This process was informed by stats printed by running `eval_property_signatures.py` and `property_signatures.py`. (I also added a few properties that helped distinguish values without adding much to the length.)

Signatures are faster to process:
* We used to reduce across examples to produce `(frac_applicable, all_true, all_false, frac_true)`. I removed `all_true` and `all_false` since they are redundant with `frac_true` (especially after quantization where 0 and 1 get their own buckets). This means signatures have half as much data
* In the model, instead of processing and expanding (embedding) signatures on CPU with explicit for loops, and then moving the result to GPU, we move signatures to GPU first and then process/embed them using torch operations.

Other changes:
* We used to ignore input lists that caused a lambda to fail, because we were searching for the correct types to give. but we have since realized that all lambda inputs are ints. now, when a lambda fails (and returns None) for some inputs, we use this info in the property signature. i've added a property that says whether an object (in this case, the result of the lambda) is None, and the rest of the properties are N/A (-1 in the code, used to be None). This in turn affects the "fraction applicable" part of the property signature after reducing across examples.
* A Value that is effectively constant (does not use any input variables) has only 1 "example" in it, e.g., `value.values == [25]`. But it's possible that another Value uses input variables and comes up with the same constant, e.g., `value.values == [25, 25, 25]` for 3 examples. The search treats these values as different, as their repr is different. I've changed the repr to be the same, so these values are treated as equal.
* Change eval_property_signatures.py distance analysis to make it faster (don't process all pairs)
* Added some profiling code
* Added more statistics for the analysis script (which I'll put in a separate PR)