### PR TITLE
dataset generation changes

### DIFF
--- a/crossbeam/algorithm/baseline_enumeration.py
+++ b/crossbeam/algorithm/baseline_enumeration.py
@@ -98,7 +98,8 @@ def arg_vars_options(num_arg_vars, num_free_vars, num_bound_vars):
 
 def synthesize_baseline(task, domain, max_weight=10, timeout=5,
                         max_values_explored=None,
-                        skip_probability=0, lambda_skip_probability=0):
+                        skip_probability=0, lambda_skip_probability=0,
+                        shuffle_ops=False):
   """Synthesizes a solution using normal bottom-up enumerative search."""
   print('synthesize_baseline for task: {}'.format(task))
   start_time = timeit.default_timer()
@@ -133,6 +134,11 @@ def synthesize_baseline(task, domain, max_weight=10, timeout=5,
   value_set = set().union(*values_by_weight)
   gather_values_cache = {}
 
+  # Shuffle operations if desired.
+  operations = list(domain.operations)
+  if shuffle_ops:
+    random.shuffle(operations)
+
   output_value = value_module.OutputValue(task.outputs)
   if output_value in value_set:
     # Found solution!
@@ -146,7 +152,7 @@ def synthesize_baseline(task, domain, max_weight=10, timeout=5,
 
   for target_weight in range(2, max_weight + 1):
     for num_free_vars, op in itertools.product(
-        range(0, variables.MAX_NUM_FREE_VARS + 1), domain.operations):
+        range(0, variables.MAX_NUM_FREE_VARS + 1), operations):
       if target_weight >= max_weight and num_free_vars > 0:
         break
 

--- a/crossbeam/datasets/data_gen_flags.py
+++ b/crossbeam/datasets/data_gen_flags.py
@@ -40,7 +40,6 @@ flags.DEFINE_float('skip_probability', 0,
 flags.DEFINE_float('lambda_skip_probability', 0,
                    'Probability of skipping a lambda program during bottom-up '
                    'enumeration to enable seeing larger programs')
-flags.DEFINE_boolean('choose_half_with_lambdas', False,
-                     'Whether exactly half of the generated tasks should '
-                     'contain lambda functions.')
+flags.DEFINE_float('lambda_fraction', None,
+                   'The proportion of values in the dataset that use lambdas.')
 flags.DEFINE_boolean('verbose', False, 'whether to print generated tasks')

--- a/crossbeam/datasets/run_deepcoder_gen.sh
+++ b/crossbeam/datasets/run_deepcoder_gen.sh
@@ -16,14 +16,15 @@
 
 data_dir=$HOME/xlambda-data/deepcoder
 
-tout=1800
+tout=3600  # 1 hour.
 maxw=100  # Run until timeout.
 maxne=5
 maxni=3
-skip=0.75
-lambdaskip=0.5
+skip=0.0
+lambdaskip=0.0
+lambda_fraction=0.8
 num_proc=1  # TODO(hadai): change to whatever is reasonable
-out_dir=$data_dir/t-${tout}-maxne-${maxne}-maxni-${maxni}-skip-${skip}-lambdaskip-${lambdaskip}
+out_dir=$data_dir/t-${tout}-maxne-${maxne}-maxni-${maxni}-skip-${skip}-lambdaskip-${lambdaskip}-lambdafrac-${lambda_fraction}
 
 if [ ! -e $out_dir ];
 then
@@ -36,9 +37,9 @@ valid_file=$out_dir/valid-tasks.pkl
 python3 -m crossbeam.datasets.bottom_up_data_generation \
     --domain=deepcoder \
     --output_file=$valid_file \
-    --data_gen_seed=1 \
+    --data_gen_seed=10000 \
     --data_gen_timeout=$tout \
-    --num_tasks=1000 \
+    --num_tasks=20 \
     --num_searches=1000 \
     --min_task_weight=3 \
     --max_task_weight=$maxw \
@@ -48,7 +49,7 @@ python3 -m crossbeam.datasets.bottom_up_data_generation \
     --max_num_inputs=$maxni \
     --skip_probability=$skip \
     --lambda_skip_probability=$lambdaskip \
-    --choose_half_with_lambdas=True \
+    --lambda_fraction=${lambda_fraction} \
     --num_datagen_proc=$num_proc \
     --verbose=False
 
@@ -61,7 +62,7 @@ python3 -m crossbeam.datasets.bottom_up_data_generation \
     --output_file=$training_file \
     --data_gen_seed=0 \
     --data_gen_timeout=$tout \
-    --num_tasks=1000 \
+    --num_tasks=2000 \
     --num_searches=10000 \
     --min_task_weight=3 \
     --max_task_weight=$maxw \
@@ -71,6 +72,6 @@ python3 -m crossbeam.datasets.bottom_up_data_generation \
     --max_num_inputs=$maxni \
     --skip_probability=$skip \
     --lambda_skip_probability=$lambdaskip \
-    --choose_half_with_lambdas=True \
+    --lambda_fraction=${lambda_fraction} \
     --num_datagen_proc=$num_proc \
     --verbose=False

--- a/crossbeam/experiment/run_baseline_synthesizer.py
+++ b/crossbeam/experiment/run_baseline_synthesizer.py
@@ -44,7 +44,8 @@ def run_synthesis(domain, tasks, timeout, max_values_explored=None,
     start_time = timeit.default_timer()
     result, value_set, _, stats = baseline_enumeration.synthesize_baseline(
         task, domain, max_weight=max_weight, timeout=timeout,
-        max_values_explored=max_values_explored)
+        max_values_explored=max_values_explored,
+        shuffle_ops=False)
     elapsed_time = timeit.default_timer() - start_time
 
     json_dict['results'].append({


### PR DESCRIPTION
previously we threw away all values of the largest weight, since they'd be biased toward operations appearing first. instead of throwing them away, let's randomize for each search the order we consider operations in.

previously we chose problems such that exactly half used lambdas and half didn't. i made this a configurable fraction, and we probably want something like 80% using lambdas. (our handwritten tasks are 86% using lambdas)

