### PR TITLE
dataset generation changes

### DIFF
--- a/crossbeam/datasets/bottom_up_data_generation.py
+++ b/crossbeam/datasets/bottom_up_data_generation.py
@@ -14,16 +14,18 @@
 
 """Generates training data using a bottom-up synthesizer."""
 
+import collections
 import functools
-import itertools
+import multiprocessing
+import os
 import pickle as cp
 import random
 import timeit
-import os
+
 from absl import app
 from absl import flags
-import multiprocessing
 from tqdm import tqdm
+
 from crossbeam.algorithm import baseline_enumeration
 from crossbeam.datasets import data_gen_flags
 from crossbeam.dsl import domains
@@ -34,8 +36,9 @@ FLAGS = flags.FLAGS
 
 
 def perform_search(domain, min_weight, max_weight, num_examples, num_inputs,
-                   timeout, num_tasks, skip_probability=0,
-                   lambda_skip_probability=0, lambda_fraction=None):
+                   timeout, num_tasks_per_weight, skip_probability=0,
+                   lambda_skip_probability=0, lambda_fraction=None,
+                   shuffle_ops=False):
   """Generates training data by running bottom-up synthesizer."""
   inputs_dict = domain.inputs_dict_generator(num_inputs=num_inputs,
                                              num_examples=num_examples)
@@ -46,142 +49,151 @@ def perform_search(domain, min_weight, max_weight, num_examples, num_inputs,
   task = task_module.Task(inputs_dict, dummy_outputs)
 
   start_time = timeit.default_timer()
-  _, value_set, values_by_weight, _ = baseline_enumeration.synthesize_baseline(
+  _, _, values_by_weight, _ = baseline_enumeration.synthesize_baseline(
       task, domain, max_weight=max_weight, timeout=timeout,
       skip_probability=skip_probability,
       lambda_skip_probability=lambda_skip_probability,
-      shuffle_ops=True)
+      shuffle_ops=shuffle_ops)
   elapsed_time = timeit.default_timer() - start_time
 
   largest_weight = max(i for i in range(min_weight, max_weight + 1)
                        if values_by_weight[i])
+  max_weight = largest_weight
   print(f'Enumerated programs up to size {largest_weight} in '
         f'{elapsed_time:.2f} seconds.')
+
+  if shuffle_ops and elapsed_time > timeout:
+    # If timeout, we didn't finish enumerating the largest weight. We want to
+    # avoid biasing toward ops considered first.
+    # We can keep values of the largest weight if we found some lambdas with
+    # that weight (which means we finished enumerating non-lambdas first).
+    if any(v.num_free_variables > 0 for v in values_by_weight[largest_weight]):
+      max_weight = largest_weight
+    else:
+      # We didn't finish enumerating non-lambdas. Throw out everything with the
+      # largest weight.
+      max_weight = largest_weight - 1
+    print('Reached timeout. Enumerated programs up to size', max_weight)
+
   print(f'Considering programs between size {min_weight} and {max_weight} '
         f'inclusive.')
 
   output_types = (domain.output_type if isinstance(domain.output_type,
                                                    (list, tuple))
                   else [domain.output_type])
-  choices = []
-  for v in value_set:
-    expression = v.expression()
-    if (min_weight <= v.get_weight() <= max_weight and
-        (domain.output_type is None or v.type in output_types) and
-        all(input_name in expression for input_name in inputs_dict)):
-      choices.append(v)
-  num_choices = len(choices)
-  print(f'Found {num_choices} choices.')
-  random.shuffle(choices)
 
-  if lambda_fraction is not None:
-    assert 0 <= lambda_fraction <= 1
-    assert isinstance(num_tasks, int)
+  tasks_by_weight = {}
 
-    target_num_with_lambda = round(num_tasks * lambda_fraction)
-    target_num_without_lambda = num_tasks - target_num_with_lambda
-    choices_with_lambda = [v for v in choices if v.contains_lambda]
-    choices_without_lambda = [v for v in choices if not v.contains_lambda]
-    print(f'{len(choices_with_lambda)} values have lambdas, and '
-          f'{len(choices_without_lambda)} values do not.')
-
-    if target_num_with_lambda > len(choices_with_lambda):
-      # We don't have enough values with lambdas. Use them all and fill the rest
-      # with values without lambdas.
-      choices_without_lambda = (
-          choices_without_lambda[:num_tasks - len(choices_with_lambda)])
-    elif target_num_without_lambda > len(choices_without_lambda):
-      # Not enough values without lambdas.
-      choices_with_lambda = (
-          choices_with_lambda[:num_tasks - len(choices_without_lambda)])
-    else:
-      # We have enough values of both kinds.
-      choices_with_lambda = choices_with_lambda[:target_num_with_lambda]
-      choices_without_lambda = choices_without_lambda[:target_num_without_lambda]
-
-    print(f'Choosing {len(choices_with_lambda)} values with lambdas, and '
-          f'{len(choices_without_lambda)} values without lambdas.')
-    choices = choices_with_lambda + choices_without_lambda
+  for weight in range(min_weight, max_weight + 1):
+    choices = []
+    for v in values_by_weight[weight]:
+      expression = v.expression()
+      if ((domain.output_type is None or v.type in output_types) and
+          all(input_name in expression for input_name in inputs_dict)):
+        choices.append(v)
+    num_choices = len(choices)
+    print(f'Found {num_choices} choices for weight {weight}.')
     random.shuffle(choices)
 
-    assert len(choices) <= num_tasks
-    if len(choices) < num_tasks:
-      assert len(choices) == num_choices  # We used everything we had.
+    if lambda_fraction is not None:
+      assert 0 <= lambda_fraction <= 1
+      assert isinstance(num_tasks_per_weight, int)
 
-  single_split = isinstance(num_tasks, int)
-  if single_split:
-    num_tasks = min(num_tasks, len(choices))
-    num_tasks = [num_tasks]
+      target_num_with_lambda = round(num_tasks_per_weight * lambda_fraction)
+      target_num_without_lambda = num_tasks_per_weight - target_num_with_lambda
+      choices_with_lambda = [v for v in choices if v.contains_lambda]
+      choices_without_lambda = [v for v in choices if not v.contains_lambda]
+      print(f'{len(choices_with_lambda)} values have lambdas, and '
+            f'{len(choices_without_lambda)} values do not.')
 
-  assert isinstance(num_tasks, (list, tuple))
-  if sum(num_tasks) > len(choices):
-    raise ValueError(
-        'Splits sum to {} tasks, but there are only {} values'.format(
-            sum(num_tasks), len(choices)))
+      if target_num_with_lambda > len(choices_with_lambda):
+        # We don't have enough values with lambdas. Use them all and fill the
+        # rest with values without lambdas.
+        choices_without_lambda = choices_without_lambda[
+            : num_tasks_per_weight - len(choices_with_lambda)]
+      elif target_num_without_lambda > len(choices_without_lambda):
+        # Not enough values without lambdas.
+        choices_with_lambda = choices_with_lambda[
+            : num_tasks_per_weight - len(choices_without_lambda)]
+      else:
+        # We have enough values of both kinds.
+        choices_with_lambda = choices_with_lambda[:target_num_with_lambda]
+        choices_without_lambda = choices_without_lambda[
+            :target_num_without_lambda]
 
-  splits = []
-  last_index = 0
-  for split_num_tasks in num_tasks:
-    this_split = [task_module.Task(inputs_dict, v.values, solution=v)
-                  for v in choices[last_index : last_index + split_num_tasks]]
-    assert len(this_split) == split_num_tasks
-    last_index += split_num_tasks
-    splits.append(this_split)
+      print(f'Choosing {len(choices_with_lambda)} values with lambdas, and '
+            f'{len(choices_without_lambda)} values without lambdas.')
+      choices = choices_with_lambda + choices_without_lambda
+      random.shuffle(choices)
 
-  if single_split:
-    assert len(splits) == 1
-    return splits[0]
-  else:
-    return splits
+      assert len(choices) <= num_tasks_per_weight
+      if len(choices) < num_tasks_per_weight:
+        assert len(choices) == num_choices  # We used everything we had.
+
+    tasks_by_weight[weight] = [
+        task_module.Task(inputs_dict, v.values, solution=v)
+        for v in choices]
+
+  return tasks_by_weight
 
 
 def generate_data(domain, min_weight, max_weight,
                   min_num_examples, max_num_examples,
                   min_num_inputs, max_num_inputs,
-                  timeout, num_searches, num_tasks_per_search,
+                  timeout, num_searches, num_tasks_per_weight,
                   skip_probability=0, lambda_skip_probability=0,
-                  lambda_fraction=None):
+                  lambda_fraction=None, shuffle_ops=False):
   """Generates and writes data by running multiple searches."""
-  tasks = []
+  tasks_by_weight = collections.defaultdict(list)
+  num_total_tasks = 0
   for i in range(num_searches):
     num_examples = random.randint(min_num_examples, max_num_examples)
     num_inputs = random.randint(min_num_inputs, max_num_inputs)
-    tasks.extend(perform_search(
+    new_tasks_by_weight = perform_search(
         domain, min_weight, max_weight, num_examples, num_inputs, timeout,
-        num_tasks=num_tasks_per_search, skip_probability=skip_probability,
+        num_tasks_per_weight=num_tasks_per_weight,
+        skip_probability=skip_probability,
         lambda_skip_probability=lambda_skip_probability,
-        lambda_fraction=lambda_fraction))
-    print('Completed search {} of {}. {} tasks total.'.format(i+1, num_searches, len(tasks)))
-  return tasks
+        lambda_fraction=lambda_fraction,
+        shuffle_ops=shuffle_ops)
+    for weight, new_tasks in new_tasks_by_weight.items():
+      tasks_by_weight[weight].extend(new_tasks)
+      num_total_tasks += len(new_tasks)
+    print(f'Completed search {i+1} of {num_searches}. '
+          f'{num_total_tasks} tasks total.')
+  return tasks_by_weight
 
 
 def datagen_worker(seed,
                    domain, min_weight, max_weight,
                    min_num_examples, max_num_examples,
                    min_num_inputs, max_num_inputs,
-                   timeout, num_tasks, skip_probability=0,
-                   lambda_skip_probability=0, lambda_fraction=None):
+                   timeout, num_tasks_per_weight, skip_probability=0,
+                   lambda_skip_probability=0, lambda_fraction=None,
+                   shuffle_ops=False):
+  """A job to run in parallel using a multiprocessing pool."""
   exp_common.set_global_seed(seed)
   num_examples = random.randint(min_num_examples, max_num_examples)
   num_inputs = random.randint(min_num_inputs, max_num_inputs)
-  tasks = perform_search(
+  tasks_by_weight = perform_search(
       domain, min_weight, max_weight, num_examples, num_inputs, timeout,
-      num_tasks=num_tasks, skip_probability=skip_probability,
+      num_tasks_per_weight=num_tasks_per_weight,
+      skip_probability=skip_probability,
       lambda_skip_probability=lambda_skip_probability,
-      lambda_fraction=lambda_fraction)
-  return tasks
+      lambda_fraction=lambda_fraction,
+      shuffle_ops=shuffle_ops)
+  return tasks_by_weight
 
 
 def main(argv):
   del argv
   exp_common.set_global_seed(FLAGS.data_gen_seed)
-  outfolder = os.path.dirname(FLAGS.output_file)
-  if not os.path.exists(outfolder):
-    os.makedirs(outfolder)
+  if not os.path.exists(FLAGS.data_save_dir):
+    os.makedirs(FLAGS.data_save_dir)
 
   domain = domains.get_domain(FLAGS.domain)
   if FLAGS.num_datagen_proc == 1:
-    tasks = generate_data(
+    tasks_by_weight = generate_data(
         domain,
         min_weight=FLAGS.min_task_weight,
         max_weight=FLAGS.max_task_weight,
@@ -191,28 +203,32 @@ def main(argv):
         max_num_inputs=FLAGS.max_num_inputs,
         timeout=FLAGS.data_gen_timeout,
         num_searches=FLAGS.num_searches,
-        num_tasks_per_search=FLAGS.num_tasks,
+        num_tasks_per_weight=FLAGS.num_tasks_per_weight,
         skip_probability=FLAGS.skip_probability,
         lambda_skip_probability=FLAGS.lambda_skip_probability,
-        lambda_fraction=FLAGS.lambda_fraction)
+        lambda_fraction=FLAGS.lambda_fraction,
+        shuffle_ops=FLAGS.shuffle_ops)
 
     if FLAGS.verbose:
-      for i, task in enumerate(tasks):
-        print('Task #{}: {}'.format(i, task))
+      for weight in sorted(tasks_by_weight.keys()):
+        for i, task in enumerate(tasks_by_weight[weight]):
+          print(f'Task #{i} for weight {weight}: {task}')
 
-    with open(FLAGS.output_file, 'wb') as f:
-      cp.dump(tasks, f, cp.HIGHEST_PROTOCOL)
+    for weight in sorted(tasks_by_weight.keys()):
+      filename = os.path.join(FLAGS.data_save_dir,
+                              f'{FLAGS.split}-weight-{weight}.pkl')
+      with open(filename, 'wb') as f:
+        cp.dump(tasks_by_weight[weight], f, cp.HIGHEST_PROTOCOL)
+
   else:
-    pool = multiprocessing.Pool(FLAGS.num_datagen_proc)
-    seeds = list(range(FLAGS.data_gen_seed, FLAGS.data_gen_seed + FLAGS.num_searches))
-    total_num_tasks = 0
-    n_shards = FLAGS.shard_start_index
-    save_prefix = '.'.join(FLAGS.output_file.split('.')[:-1])
-    all_tasks = []
-    def save_shard(t_list, n_shards):
-      with open(save_prefix + '-%05d.pkl' % n_shards, 'wb') as f:
-        cp.dump(t_list, f, cp.HIGHEST_PROTOCOL)
-      return n_shards + 1
+
+    def save_shard(task_list, weight, shard_index):
+      filename = os.path.join(
+          FLAGS.data_save_dir,
+          f'{FLAGS.split}-weight-{weight}-{shard_index:05d}.pkl')
+      with open(filename, 'wb') as f:
+        cp.dump(task_list, f, cp.HIGHEST_PROTOCOL)
+
     worker_fun = functools.partial(
         datagen_worker, domain=domain,
         min_weight=FLAGS.min_task_weight,
@@ -222,19 +238,42 @@ def main(argv):
         min_num_inputs=FLAGS.min_num_inputs,
         max_num_inputs=FLAGS.max_num_inputs,
         timeout=FLAGS.data_gen_timeout,
-        num_tasks=FLAGS.num_tasks,
+        num_tasks_per_weight=FLAGS.num_tasks_per_weight,
         skip_probability=FLAGS.skip_probability,
         lambda_skip_probability=FLAGS.lambda_skip_probability,
-        lambda_fraction=FLAGS.lambda_fraction)
-    for local_tasks in tqdm(pool.imap_unordered(worker_fun, seeds), total=len(seeds)):
-      total_num_tasks += len(local_tasks)
-      all_tasks.extend(local_tasks)
-      while len(all_tasks) >= FLAGS.shard_size:
-        n_shards = save_shard(all_tasks[:FLAGS.shard_size], n_shards)
-        all_tasks = all_tasks[FLAGS.shard_size:]
-    if len(all_tasks):
-      save_shard(all_tasks, n_shards)
-    print('total # generated tasks', total_num_tasks)
+        lambda_fraction=FLAGS.lambda_fraction,
+        shuffle_ops=FLAGS.shuffle_ops)
+
+    pool = multiprocessing.Pool(FLAGS.num_datagen_proc)
+    seeds = list(range(FLAGS.data_gen_seed,
+                       FLAGS.data_gen_seed + FLAGS.num_searches))
+    shard_index_per_weight = {
+        weight: FLAGS.shard_start_index
+        for weight in range(FLAGS.min_task_weight, FLAGS.max_task_weight + 1)
+    }
+    tasks_by_weight = collections.defaultdict(list)
+    total_num_tasks = 0
+
+    for local_tasks_by_weight in tqdm(pool.imap_unordered(worker_fun, seeds),
+                                      total=len(seeds)):
+      for weight in sorted(local_tasks_by_weight.keys()):
+        local_tasks = local_tasks_by_weight[weight]
+        total_num_tasks += len(local_tasks)
+        tasks_by_weight[weight].extend(local_tasks)
+        while len(tasks_by_weight[weight]) >= FLAGS.shard_size:
+          save_shard(task_list=tasks_by_weight[weight][:FLAGS.shard_size],
+                     weight=weight,
+                     shard_index=shard_index_per_weight[weight])
+          shard_index_per_weight[weight] += 1
+          tasks_by_weight[weight] = tasks_by_weight[weight][FLAGS.shard_size:]
+
+    for weight in sorted(tasks_by_weight.keys()):
+      if tasks_by_weight[weight]:
+        save_shard(task_list=tasks_by_weight[weight],
+                   weight=weight,
+                   shard_index=shard_index_per_weight[weight])
+
+    print(f'total # generated tasks: {total_num_tasks}')
 
 
 if __name__ == '__main__':

--- a/crossbeam/datasets/bottom_up_data_generation.py
+++ b/crossbeam/datasets/bottom_up_data_generation.py
@@ -188,8 +188,10 @@ def datagen_worker(seed,
 def main(argv):
   del argv
   exp_common.set_global_seed(FLAGS.data_gen_seed)
-  if not os.path.exists(FLAGS.data_save_dir):
+  try:
     os.makedirs(FLAGS.data_save_dir)
+  except FileExistsError:
+    pass  # If we check if the path exists, we can still have a race condition.
 
   domain = domains.get_domain(FLAGS.domain)
   if FLAGS.num_datagen_proc == 1:

--- a/crossbeam/datasets/data_gen_flags.py
+++ b/crossbeam/datasets/data_gen_flags.py
@@ -19,14 +19,16 @@ from absl import flags
 FLAGS = flags.FLAGS
 
 flags.DEFINE_integer('data_gen_seed', 1, 'Seed for data generation')
-flags.DEFINE_integer('shard_start_index', 0, 'starting index of shards for current job')
+flags.DEFINE_integer('shard_start_index', 0,
+                     'starting index of shards for current job')
 flags.DEFINE_enum('domain', 'tuple',
                   ['tuple', 'arithmetic', 'bustle', 'logic', 'deepcoder'],
                   'task domain')
-flags.DEFINE_string('output_file', None, 'data dump')
+flags.DEFINE_string('data_save_dir', None, 'Where to save data')
+flags.DEFINE_string('split', 'train', 'the split for dataset generation')
 flags.DEFINE_integer('num_datagen_proc', 1, '# processes for data gen')
 flags.DEFINE_integer('shard_size', 100000, '# tasks per file')
-flags.DEFINE_integer('num_tasks', 1000, '# tasks')
+flags.DEFINE_integer('num_tasks_per_weight', 1000, '# tasks for each weight')
 flags.DEFINE_integer('num_searches', 100, '# searches to perform')
 flags.DEFINE_float('data_gen_timeout', 60, 'timeout per search in seconds')
 flags.DEFINE_integer('min_num_examples', 2, '')
@@ -43,4 +45,11 @@ flags.DEFINE_float('lambda_skip_probability', 0,
                    'enumeration to enable seeing larger programs')
 flags.DEFINE_float('lambda_fraction', None,
                    'The proportion of values in the dataset that use lambdas.')
+flags.DEFINE_boolean('shuffle_ops', False,
+                     'Whether to shuffle the order of ops considered during '
+                     'bottom-up search for data generation. If False, we might '
+                     'throw away values of the largest weight to avoid biasing '
+                     'toward values using ops considered first. If True, we do '
+                     'not throw away anything, but the distribution of tasks '
+                     'might change due to the different ordering of ops.')
 flags.DEFINE_boolean('verbose', False, 'whether to print generated tasks')

--- a/crossbeam/datasets/deepcoder_data.py
+++ b/crossbeam/datasets/deepcoder_data.py
@@ -1,5 +1,6 @@
 """Creates random input data for DeepCoder problems."""
 
+import itertools
 import random
 
 # Ranges have inclusive endpoints and are paired with sampling weights.
@@ -89,63 +90,73 @@ def random_int_list(input_format):
 
 def deepcoder_inputs_dict_generator(num_inputs, num_examples):
   """Returns a dict of random inputs for DeepCoder."""
-  inputs_dict = {}
-  input_names = []
-  input_formats = []
-  input_types = []
+  while True:  # Try until there are no identical inputs or examples.
+    inputs_dict = {}
+    input_names = []
+    input_formats = []
+    input_types = []
 
-  for i in range(num_inputs):
-    input_name = f'x{i + 1}'
-    input_type = random.choice(['int', 'int_list'])
+    for i in range(num_inputs):
+      input_name = f'x{i + 1}'
+      input_type = random.choice(['int', 'int_list', 'int_list'])
 
-    copy_list_lengths_index = -1
+      copy_list_lengths_index = -1
 
-    if i > 0 and flip():
-      # Copy the format of some previous input. The input type might be
-      # different, but the range of ints would be the same.
-      index_to_copy = random.randrange(i)
-      input_format = input_formats[index_to_copy]
-      if (input_type == 'int_list' and input_types[index_to_copy] == 'int_list'
-          and flip(0.75)):
-        copy_list_lengths_index = index_to_copy
-    else:
-      input_format = {}
+      if i > 0 and flip():
+        # Copy the format of some previous input. The input type might be
+        # different, but the range of ints would be the same.
+        index_to_copy = random.randrange(i)
+        input_format = input_formats[index_to_copy]
+        if (input_type == 'int_list'
+            and input_types[index_to_copy] == 'int_list' and flip(0.75)):
+          copy_list_lengths_index = index_to_copy
+      else:
+        input_format = {}
 
-    if 'int_range' not in input_format:
-      int_range, _ = random.choices(INT_RANGES, weights=_INT_RANGES_WEIGHTS,
-                                    k=1)[0]
-      input_format['int_range'] = int_range
+      if 'int_range' not in input_format:
+        int_range, _ = random.choices(INT_RANGES, weights=_INT_RANGES_WEIGHTS,
+                                      k=1)[0]
+        input_format['int_range'] = int_range
 
-    if input_type == 'int':
-      input_creator_fn = random_int
+      if input_type == 'int':
+        input_creator_fn = random_int
 
-    elif input_type == 'int_list':
-      input_creator_fn = random_int_list
-      if 'length_range' not in input_format:
-        length_range, _ = random.choices(LENGTH_RANGES,
-                                         weights=_LENGTH_RANGES_WEIGHTS, k=1)[0]
-        input_format['length_range'] = length_range
-        input_format['unique'] = flip(0.25)
-        input_format['sort'] = random.choices(['none', 'inc', 'dec'],
-                                              weights=[7, 2, 1], k=1)[0]
+      elif input_type == 'int_list':
+        input_creator_fn = random_int_list
+        if 'length_range' not in input_format:
+          length_range, _ = random.choices(
+              LENGTH_RANGES, weights=_LENGTH_RANGES_WEIGHTS, k=1)[0]
+          input_format['length_range'] = length_range
+          input_format['unique'] = flip(0.25)
+          input_format['sort'] = random.choices(['none', 'inc', 'dec'],
+                                                weights=[7, 2, 1], k=1)[0]
 
-    else:
-      raise ValueError(f'Unhandled input_type: {input_type}')
+      else:
+        raise ValueError(f'Unhandled input_type: {input_type}')
 
-    if copy_list_lengths_index != -1:
-      input_examples = []
-      for other_list in inputs_dict[input_names[copy_list_lengths_index]]:
-        specific_len_input_format = input_format.copy()
-        list_len = len(other_list)
-        specific_len_input_format['length_range'] = (list_len, list_len)
-        input_examples.append(input_creator_fn(specific_len_input_format))
-    else:
-      input_examples = [input_creator_fn(input_format)
-                        for _ in range(num_examples)]
-    inputs_dict[input_name] = input_examples
+      if copy_list_lengths_index != -1:
+        input_examples = []
+        for other_list in inputs_dict[input_names[copy_list_lengths_index]]:
+          specific_len_input_format = input_format.copy()
+          list_len = len(other_list)
+          specific_len_input_format['length_range'] = (list_len, list_len)
+          input_examples.append(input_creator_fn(specific_len_input_format))
+      else:
+        input_examples = [input_creator_fn(input_format)
+                          for _ in range(num_examples)]
+      inputs_dict[input_name] = input_examples
 
-    input_names.append(input_name)
-    input_formats.append(input_format)
-    input_types.append(input_type)
+      input_names.append(input_name)
+      input_formats.append(input_format)
+      input_types.append(input_type)
 
-  return inputs_dict
+    ok = True
+    for name_1, name_2 in itertools.combinations(input_names, 2):
+      if inputs_dict[name_1] == inputs_dict[name_2]:
+        ok = False
+    for example_1, example_2 in itertools.combinations(range(num_examples), 2):
+      if all(inputs_dict[name][example_1] == inputs_dict[name][example_2]
+             for name in input_names):
+        ok = False
+    if ok:
+      return inputs_dict

--- a/crossbeam/datasets/deepcoder_data_test.py
+++ b/crossbeam/datasets/deepcoder_data_test.py
@@ -1,0 +1,33 @@
+"""Tests for crossbeam.datasets.deepcoder_data_test."""
+
+import itertools
+import random
+
+from absl.testing import absltest
+
+from crossbeam.datasets import deepcoder_data
+
+
+class BottomUpDataGenerationTest(absltest.TestCase):
+
+  def test_deepcoder_inputs_dict_generator(self):
+    for _ in range(100):
+      num_inputs = random.randint(1, 3)
+      num_examples = random.randint(2, 5)
+      inputs_dict = deepcoder_data.deepcoder_inputs_dict_generator(
+          num_inputs=num_inputs, num_examples=num_examples)
+
+      # No two input variables are identical.
+      for name_1, name_2 in itertools.combinations(inputs_dict.keys(), 2):
+        self.assertNotEqual(inputs_dict[name_1], inputs_dict[name_2])
+
+      # No two examples are identical.
+      for index_1, index_2 in itertools.combinations(range(num_examples), 2):
+        example_1 = {name: values[index_1]
+                     for name, values in inputs_dict.items()}
+        example_2 = {name: values[index_2]
+                     for name, values in inputs_dict.items()}
+        self.assertNotEqual(example_1, example_2)
+
+if __name__ == '__main__':
+  absltest.main()

--- a/crossbeam/datasets/launch_xm_deepcoder_gen.sh
+++ b/crossbeam/datasets/launch_xm_deepcoder_gen.sh
@@ -4,7 +4,7 @@ tout=3600
 split=valid
 num_tasks_per_weight=5
 num_searches=1000  # Total across all workers
-num_workers=250
+num_workers=50
 num_proc=4
 lambda_fraction=0.8
 shuffle_ops=False
@@ -12,6 +12,7 @@ start_seed=0
 
 xmanager launch \
   xm_datagen.py -- \
+  --noxm_monitor_on_launch \
   --xm_resource_alloc="user:xcloud/${USER}" \
   --xm_gcs_path=/gcs/xcloud-shared/${USER}/xlambda \
   --user=${USER} \
@@ -37,14 +38,15 @@ xmanager launch \
 
 
 split=train
-num_tasks_per_weight=100
+num_tasks_per_weight=200
 num_searches=10000  # Total across all workers
-num_workers=2500
+num_workers=500
 num_proc=4
 start_seed=10000
 
 xmanager launch \
   xm_datagen.py -- \
+  --noxm_monitor_on_launch \
   --xm_resource_alloc="user:xcloud/${USER}" \
   --xm_gcs_path=/gcs/xcloud-shared/${USER}/xlambda \
   --user=${USER} \

--- a/crossbeam/datasets/launch_xm_deepcoder_gen.sh
+++ b/crossbeam/datasets/launch_xm_deepcoder_gen.sh
@@ -1,24 +1,26 @@
 #!/bin/bash
 
 tout=3600
-maxw=100  # Run until timeout.
+maxw=15  # Run until timeout.
 maxne=5
 maxni=3
 skip=0.0
 lambdaskip=0.0
 lambda_fraction=0.8
+shuffle_ops=False
 num_proc=4
 num_workers=2000
-phase=train
+split=train
 start_seed=1000000
 
 xmanager launch \
   xm_datagen.py -- \
   --xm_resource_alloc="user:xcloud/${USER}" \
   --xm_gcs_path=/gcs/xcloud-shared/${USER}/xlambda \
-  --name_prefix=$phase \
+  --user=${USER} \
+  --split=$split \
   --tout=$tout \
-  --num_tasks=1600 \
+  --num_tasks_per_weight=200 \
   --num_searches=10000 \
   --num_workers=$num_workers \
   --min_task_weight=3 \
@@ -30,5 +32,6 @@ xmanager launch \
   --skip=$skip \
   --lambdaskip=$lambdaskip \
   --lambda_fraction=$lambda_fraction \
+  --shuffle_ops=$shuffle_ops \
   --start_seed=$start_seed \
   --num_proc=$num_proc

--- a/crossbeam/datasets/launch_xm_deepcoder_gen.sh
+++ b/crossbeam/datasets/launch_xm_deepcoder_gen.sh
@@ -1,37 +1,69 @@
 #!/bin/bash
 
 tout=3600
-maxw=15  # Run until timeout.
-maxne=5
-maxni=3
-skip=0.0
-lambdaskip=0.0
+split=valid
+num_tasks_per_weight=5
+num_searches=1000  # Total across all workers
+num_workers=250
+num_proc=4
 lambda_fraction=0.8
 shuffle_ops=False
-num_proc=4
-num_workers=2000
-split=train
-start_seed=1000000
+start_seed=0
 
 xmanager launch \
   xm_datagen.py -- \
   --xm_resource_alloc="user:xcloud/${USER}" \
   --xm_gcs_path=/gcs/xcloud-shared/${USER}/xlambda \
   --user=${USER} \
-  --split=$split \
+  --exp_name=gen-deepcoder-${split}-data \
+  --domain=deepcoder \
   --tout=$tout \
-  --num_tasks_per_weight=200 \
-  --num_searches=10000 \
+  --split=$split \
+  --num_tasks_per_weight=$num_tasks_per_weight \
+  --num_searches=$num_searches \
   --num_workers=$num_workers \
+  --num_proc=$num_proc \
   --min_task_weight=3 \
-  --maxw=$maxw \
+  --max_task_weight=15 \
   --min_num_examples=2 \
-  --maxne=$maxne \
+  --max_num_examples=5 \
   --min_num_inputs=1 \
-  --maxni=$maxni \
-  --skip=$skip \
-  --lambdaskip=$lambdaskip \
+  --max_num_inputs=3 \
+  --skip=0.0 \
+  --lambdaskip=0.0 \
   --lambda_fraction=$lambda_fraction \
   --shuffle_ops=$shuffle_ops \
   --start_seed=$start_seed \
-  --num_proc=$num_proc
+
+
+split=train
+num_tasks_per_weight=100
+num_searches=10000  # Total across all workers
+num_workers=2500
+num_proc=4
+start_seed=10000
+
+xmanager launch \
+  xm_datagen.py -- \
+  --xm_resource_alloc="user:xcloud/${USER}" \
+  --xm_gcs_path=/gcs/xcloud-shared/${USER}/xlambda \
+  --user=${USER} \
+  --exp_name=gen-deepcoder-${split}-data \
+  --domain=deepcoder \
+  --tout=$tout \
+  --split=$split \
+  --num_tasks_per_weight=$num_tasks_per_weight \
+  --num_searches=$num_searches \
+  --num_workers=$num_workers \
+  --num_proc=$num_proc \
+  --min_task_weight=3 \
+  --max_task_weight=15 \
+  --min_num_examples=2 \
+  --max_num_examples=5 \
+  --min_num_inputs=1 \
+  --max_num_inputs=3 \
+  --skip=0.0 \
+  --lambdaskip=0.0 \
+  --lambda_fraction=$lambda_fraction \
+  --shuffle_ops=$shuffle_ops \
+  --start_seed=$start_seed \

--- a/crossbeam/datasets/run_deepcoder_gen.sh
+++ b/crossbeam/datasets/run_deepcoder_gen.sh
@@ -17,14 +17,15 @@
 data_dir=$HOME/xlambda-data/deepcoder
 
 tout=3600  # 1 hour.
-maxw=100  # Run until timeout.
+maxw=15  # Run until timeout.
 maxne=5
 maxni=3
 skip=0.0
 lambdaskip=0.0
 lambda_fraction=0.8
-num_proc=1  # TODO(hadai): change to whatever is reasonable
-out_dir=$data_dir/t-${tout}-maxne-${maxne}-maxni-${maxni}-skip-${skip}-lambdaskip-${lambdaskip}-lambdafrac-${lambda_fraction}
+shuffle_ops=False
+num_proc=1
+out_dir=$data_dir/t-${tout}-maxne-${maxne}-maxni-${maxni}-skip-${skip}-lambdaskip-${lambdaskip}-lambdafrac-${lambda_fraction}-shuffleops-${shuffle_ops}
 
 if [ ! -e $out_dir ];
 then
@@ -32,14 +33,13 @@ then
 fi
 
 echo 'Generating validation'
-valid_file=$out_dir/valid-tasks.pkl
-
 python3 -m crossbeam.datasets.bottom_up_data_generation \
     --domain=deepcoder \
-    --output_file=$valid_file \
+    --data_save_dir=$out_dir \
+    --split=valid \
     --data_gen_seed=10000 \
     --data_gen_timeout=$tout \
-    --num_tasks=20 \
+    --num_tasks_per_weight=10 \
     --num_searches=1000 \
     --min_task_weight=3 \
     --max_task_weight=$maxw \
@@ -50,19 +50,18 @@ python3 -m crossbeam.datasets.bottom_up_data_generation \
     --skip_probability=$skip \
     --lambda_skip_probability=$lambdaskip \
     --lambda_fraction=${lambda_fraction} \
+    --shuffle_ops=${shuffle_ops} \
     --num_datagen_proc=$num_proc \
     --verbose=False
 
 echo 'Generating training'
-
-training_file=$out_dir/train-tasks.pkl
-
 python3 -m crossbeam.datasets.bottom_up_data_generation \
     --domain=deepcoder \
-    --output_file=$training_file \
+    --data_save_dir=$out_dir \
+    --split=train \
     --data_gen_seed=0 \
     --data_gen_timeout=$tout \
-    --num_tasks=2000 \
+    --num_tasks_per_weight=100 \
     --num_searches=10000 \
     --min_task_weight=3 \
     --max_task_weight=$maxw \
@@ -73,5 +72,6 @@ python3 -m crossbeam.datasets.bottom_up_data_generation \
     --skip_probability=$skip \
     --lambda_skip_probability=$lambdaskip \
     --lambda_fraction=${lambda_fraction} \
+    --shuffle_ops=${shuffle_ops} \
     --num_datagen_proc=$num_proc \
     --verbose=False

--- a/crossbeam/xm_datagen.py
+++ b/crossbeam/xm_datagen.py
@@ -1,35 +1,40 @@
+"""XM script to run bottom-up data generation."""
+
+import math
 from absl import app
 from absl import flags
-import os
 from xmanager import xm
 from xmanager import xm_abc
 from xmanager.contrib import framework_defaults
-from xmanager.contrib import gcs
+from xmanager.contrib import gcs  # pylint: disable=unused-import
 
 
 _EXP_NAME = flags.DEFINE_string(
-  'exp_name', 'deepcoder', 'Name of the experiment.', short_name='n')
+    'exp_name', 'gen-deepcoder-data', 'Name of the experiment.', short_name='n')
+_DOMAIN = flags.DEFINE_string(
+    'domain', 'deepcoder', 'What domain to use')
 
 flags.DEFINE_integer('tout', 1800, 'timeout')
-flags.DEFINE_integer('maxw', 100, 'max search weights')
-flags.DEFINE_integer('maxne', 5, 'max num ex')
-flags.DEFINE_integer('maxni', 3, 'max num input')
 flags.DEFINE_integer('start_seed', 0, 'offset of seed, to separate train/valid')
-flags.DEFINE_float('skip', 0.75, 'skip')
-flags.DEFINE_float('lambdaskip', 0.5, 'lambdaskip')
+flags.DEFINE_float('skip', 0.0, 'skip')
+flags.DEFINE_float('lambdaskip', 0.0, 'lambdaskip')
 flags.DEFINE_float('lambda_fraction', 0.8, 'lambda_fraction')
 flags.DEFINE_boolean('shuffle_ops', False, 'shuffle ops during data gen?')
-flags.DEFINE_integer('num_proc', 1, 'num processes')
 flags.DEFINE_string('user', None, 'Whose xcloud-shared folder to save in')
 flags.DEFINE_string('split', 'train', 'split')
 flags.DEFINE_integer('num_searches', 1000, 'num searches')
-flags.DEFINE_integer('num_tasks_per_weight', 1000, 'num tasks per weight, per search')
+flags.DEFINE_integer('num_tasks_per_weight', 1000,
+                     'num tasks per weight, per search')
 flags.DEFINE_integer('min_task_weight', 3, 'min task weight')
+flags.DEFINE_integer('max_task_weight', 100, 'max task weight')
 flags.DEFINE_integer('min_num_inputs', 1, 'min num inputs')
-flags.DEFINE_integer('min_num_examples', 2, 'min num ex')
+flags.DEFINE_integer('max_num_inputs', 3, 'max num input')
+flags.DEFINE_integer('min_num_examples', 2, 'min num examples')
+flags.DEFINE_integer('max_num_examples', 5, 'max num examples')
 flags.DEFINE_integer('shard_size', 100000, 'shard size')
 
 flags.DEFINE_integer('num_workers', 10, 'num jobs')
+flags.DEFINE_integer('num_proc', 1, 'num processes per worker')
 
 FLAGS = flags.FLAGS
 
@@ -39,52 +44,54 @@ def main(argv) -> None:
     raise app.UsageError('Too many command-line arguments.')
   assert FLAGS.num_proc > 1  # sharding enabled only for multi-proc jobs
   with xm_abc.create_experiment(experiment_title=_EXP_NAME.value) as experiment:
-    job_requirements = xm.JobRequirements(ram=25 * FLAGS.num_proc * xm.GiB, cpu=FLAGS.num_proc)
+    job_requirements = xm.JobRequirements(ram=25 * FLAGS.num_proc * xm.GiB,
+                                          cpu=FLAGS.num_proc + 1)
     executor = xm_abc.executors.Gcp(requirements=job_requirements)
 
-    data_folder = 't-%d-maxne-%d-maxni-%d-skip-%.2f-lambdaskip-%.2f-lambdafrac-%.2f-shuffleops-%s' % (
-      FLAGS.tout, FLAGS.maxne, FLAGS.maxni, FLAGS.skip, FLAGS.lambdaskip, FLAGS.lambda_fraction, FLAGS.shuffle_ops
-    )
-    data_save_dir = '/gcs/xcloud-shared/%s/data/xlambda/%s' % (FLAGS.user, data_folder)
-    num_searches = FLAGS.num_searches // FLAGS.num_workers
-    if FLAGS.num_searches % FLAGS.num_workers > 0:
-      num_searches += 1
+    data_folder = (
+        f't-{FLAGS.tout}-searches-{FLAGS.num_searches}-tasks-{FLAGS.num_tasks_per_weight}-'
+        f'lambdafrac-{FLAGS.lambda_fraction}-shuffleops-{FLAGS.shuffle_ops}')
+    data_save_dir = (
+        f'/gcs/xcloud-shared/{FLAGS.user}/data/xlambda/{data_folder}')
+    num_searches = math.ceil(FLAGS.num_searches / FLAGS.num_workers)
     executable_args = {
-      'domain': _EXP_NAME.value,
-      'data_save_dir': data_save_dir,
-      'split': FLAGS.split,
-      'data_gen_timeout': FLAGS.tout,
-      'num_tasks_per_weight': FLAGS.num_tasks_per_weight,
-      'num_searches': num_searches,
-      'min_task_weight': FLAGS.min_task_weight,
-      'max_task_weight': FLAGS.maxw,
-      'min_num_examples': FLAGS.min_num_examples,
-      'max_num_examples': FLAGS.maxne,
-      'min_num_inputs': FLAGS.min_num_inputs,
-      'max_num_inputs': FLAGS.maxni,
-      'skip_probability': FLAGS.skip,
-      'lambda_skip_probability': FLAGS.lambdaskip,
-      'lambda_fraction': FLAGS.lambda_fraction,
-      'shuffle_ops': FLAGS.shuffle_ops,
-      'num_datagen_proc': FLAGS.num_proc,
-      'shard_size': FLAGS.shard_size,
-      'verbose': False
+        'domain': _DOMAIN.value,
+        'data_save_dir': data_save_dir,
+        'split': FLAGS.split,
+        'data_gen_timeout': FLAGS.tout,
+        'num_tasks_per_weight': FLAGS.num_tasks_per_weight,
+        'num_searches': num_searches,
+        'min_task_weight': FLAGS.min_task_weight,
+        'max_task_weight': FLAGS.max_task_weight,
+        'min_num_examples': FLAGS.min_num_examples,
+        'max_num_examples': FLAGS.max_num_examples,
+        'min_num_inputs': FLAGS.min_num_inputs,
+        'max_num_inputs': FLAGS.max_num_inputs,
+        'skip_probability': FLAGS.skip,
+        'lambda_skip_probability': FLAGS.lambdaskip,
+        'lambda_fraction': FLAGS.lambda_fraction,
+        'shuffle_ops': FLAGS.shuffle_ops,
+        'num_datagen_proc': FLAGS.num_proc,
+        'shard_size': FLAGS.shard_size,
+        'verbose': False,
     }
     module = 'crossbeam.datasets.bottom_up_data_generation'
     executable, = experiment.package([
-      xm.python_container(
-        path='.',
-        base_image=framework_defaults.base_image(
-          'pytorch', job_requirements.accelerator),
-        entrypoint=xm.ModuleName(module),
-        use_deep_module=True,
-        executor_spec=executor.Spec(),
-        args=executable_args)
-        ])
+        xm.python_container(
+            path='.',
+            base_image=framework_defaults.base_image(
+                'pytorch', job_requirements.accelerator),
+            entrypoint=xm.ModuleName(module),
+            use_deep_module=True,
+            executor_spec=executor.Spec(),
+            args=executable_args)
+    ])
     job = xm.Job(executable, executor)
-    nshard_per_job = num_searches * FLAGS.num_tasks_per_weight // FLAGS.shard_size + 1
-    job_configs = list([{'data_gen_seed': x * num_searches + FLAGS.start_seed,
-                         'shard_start_index': x * nshard_per_job} for x in range(FLAGS.num_workers)])
+    nshard_per_job = math.ceil(num_searches * FLAGS.num_tasks_per_weight
+                               / FLAGS.shard_size)
+    job_configs = [{'data_gen_seed': x * num_searches + FLAGS.start_seed,
+                    'shard_start_index': x * nshard_per_job}
+                   for x in range(FLAGS.num_workers)]
 
     for job_args in job_configs:
       experiment.add(job, args={'args': job_args})

--- a/crossbeam/xm_datagen.py
+++ b/crossbeam/xm_datagen.py
@@ -45,12 +45,11 @@ def main(argv) -> None:
   assert FLAGS.num_proc > 1  # sharding enabled only for multi-proc jobs
   with xm_abc.create_experiment(experiment_title=_EXP_NAME.value) as experiment:
     job_requirements = xm.JobRequirements(ram=25 * FLAGS.num_proc * xm.GiB,
-                                          cpu=FLAGS.num_proc + 1)
+                                          cpu=FLAGS.num_proc)
     executor = xm_abc.executors.Gcp(requirements=job_requirements)
 
     data_folder = (
-        f't-{FLAGS.tout}-searches-{FLAGS.num_searches}-tasks-{FLAGS.num_tasks_per_weight}-'
-        f'lambdafrac-{FLAGS.lambda_fraction}-shuffleops-{FLAGS.shuffle_ops}')
+        f't-{FLAGS.tout}-lambdafrac-{FLAGS.lambda_fraction}-shuffleops-{FLAGS.shuffle_ops}')
     data_save_dir = (
         f'/gcs/xcloud-shared/{FLAGS.user}/data/xlambda/{data_folder}')
     num_searches = math.ceil(FLAGS.num_searches / FLAGS.num_workers)


### PR DESCRIPTION
* change dataset to be split by task weight. So instead of shards like "train-tasks-001.pkl" we now get "train-weight-5-001.pkl". We sample a fixed number of tasks ("tasks_per_weight") for each weight for each search.
* when generating random inputs for bottom-up search, ensure that no 2 inputs or 2 examples are identical
* increase likelihood of a random input being a list (1/2 chance -> 2/3 chance). if a task only has ints, then it cannot use lambdas. But we can't force every task to have lists, because there are a few handwritten tasks that only use ints.
* Add a "shuffle_ops" flag. At one point I changed the behavior where, instead of throwing away values with the largest weight if we hit a timeout, I instead shuffled the order of ops considered during search. However I'm now concerned that shuffling the order of ops might change the distribution of problems we get. So now it's a flag, default to False.

I have tried the `run_deepcoder_gen.sh` script locally and it seems ok. I have not yet tried the XM launcher.

Maybe let's do a review, but not merge this until we successfully create the data via XM.